### PR TITLE
fix: cleanup pendingOperation variable after successful operation

### DIFF
--- a/android/src/main/java/xyz/luan/games/play/playgames/PlayGamesPlugin.java
+++ b/android/src/main/java/xyz/luan/games/play/playgames/PlayGamesPlugin.java
@@ -273,6 +273,7 @@ public class PlayGamesPlugin implements MethodCallHandler, ActivityResultListene
             @Override
             public void onSuccess(Intent intent) {
                 registrar.activity().startActivityForResult(intent, RC_ACHIEVEMENT_UI);
+                result(new HashMap<>());
             }
         }).addOnFailureListener(new OnFailureListener() {
             @Override
@@ -287,6 +288,7 @@ public class PlayGamesPlugin implements MethodCallHandler, ActivityResultListene
             @Override
             public void onSuccess(Intent intent) {
                 registrar.activity().startActivityForResult(intent, RC_LEADERBOARD_UI);
+                result(new HashMap<>());
             }
         }).addOnFailureListener(new OnFailureListener() {
             @Override
@@ -301,6 +303,7 @@ public class PlayGamesPlugin implements MethodCallHandler, ActivityResultListene
             @Override
             public void onSuccess(Intent intent) {
                 registrar.activity().startActivityForResult(intent, RC_ALL_LEADERBOARD_UI);
+                result(new HashMap<>());
             }
         }).addOnFailureListener(new OnFailureListener() {
             @Override


### PR DESCRIPTION
I just encountered and fixed the issue mentioned in #8
While working on fixing this issue I noticed that `showAllLeaderboards()` and `showAchievements()` have the same issue.
To fix the issue I simply added a `result(new HashMap<>());` to the `onSuccess` functions.

close #8