### PR TITLE
Fixing iOS plugin config

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,4 +22,4 @@ flutter:
         package: xyz.luan.games.play.playgames
         pluginClass: PlayGamesPlugin
       ios:
-        pluginClass: AudioplayersPlugin
+        pluginClass: PlayGamesPlugin


### PR DESCRIPTION
This wrong configuration was causing to Audioplayers been registered twice when this plugin was used along Audioplayers, which caused iOS to crash. 